### PR TITLE
♻️  Improve get ongoing trials use case

### DIFF
--- a/packages/business/src/adapters/static-file-repository.ts
+++ b/packages/business/src/adapters/static-file-repository.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 import { readFile } from 'node:fs/promises'
 
 import { COUNTRIES, ClinicalTrial } from '../domain'
-import { Filter, FindClinicalTrials } from '../ports'
+import { FindClinicalTrials } from '../ports'
 
 type ApiClinicalTrial = {
   name: string
@@ -14,10 +14,9 @@ type ApiClinicalTrial = {
 
 const TRIALS_FILE_PATH_FROM_HERE = '/../../../../trials.json'
 
-const findClinicalTrials: FindClinicalTrials = async (filter?: Filter) => {
+const findClinicalTrials: FindClinicalTrials = async () => {
   const fetchedClinicalTrials = await loadJson<ApiClinicalTrial[]>(path.join(__dirname, TRIALS_FILE_PATH_FROM_HERE))
-  const clinicalTrials = fetchedClinicalTrials.map(toClinicalTrial)
-  return filter ? filterClinicalTrials(clinicalTrials, filter) : clinicalTrials
+  return fetchedClinicalTrials.map(toClinicalTrial)
 }
 
 const loadJson = async <T = unknown>(filePath: string): Promise<T> => {
@@ -52,13 +51,5 @@ const parseDate = (englishFormat: string): Date => {
   if (isNaN(year) || isNaN(month) || isNaN(date)) throw new Error(`Bad date format ${englishFormat}`)
   return new Date(year, month - 1, date)
 }
-
-
-const filterClinicalTrials = (clinicalTrials: ClinicalTrial[], filter: Filter) =>
-  clinicalTrials.filter(trial => {
-    return (!filter.after || (trial.endDate.getTime() > filter.after.getTime()))
-      && (!filter.before || (trial.startDate.getTime() < filter.before.getTime()))
-      && (!filter.sponsorName || (trial.sponsor === filter.sponsorName))
-  })
 
 export { findClinicalTrials }

--- a/packages/business/src/adapters/static-file-repository.ts
+++ b/packages/business/src/adapters/static-file-repository.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 import { readFile } from 'node:fs/promises'
 
 import { COUNTRIES, ClinicalTrial } from '../domain'
-import { Filter, FindClinicalTrials } from '../ports/repository'
+import { Filter, FindClinicalTrials } from '../ports'
 
 type ApiClinicalTrial = {
   name: string

--- a/packages/business/src/domain/use-cases.ts
+++ b/packages/business/src/domain/use-cases.ts
@@ -1,4 +1,4 @@
-import { FindClinicalTrials } from '../ports/repository'
+import { FindClinicalTrials } from '../ports'
 import { ClinicalTrial, CountryCode } from './entities'
 
 type OnGoingFilter = { sponsorName?: string, countryCode?: CountryCode }

--- a/packages/business/src/domain/use-cases.ts
+++ b/packages/business/src/domain/use-cases.ts
@@ -6,4 +6,4 @@ type OnGoingFilter = { sponsorName?: string, countryCode?: CountryCode }
 type GetOnGoingClinicalTrials = (findOnGoingClinicalTrials: FindClinicalTrials) =>
   (filter?: OnGoingFilter) => Promise<ClinicalTrial[]>
 
-export { GetOnGoingClinicalTrials }
+export { GetOnGoingClinicalTrials, OnGoingFilter }

--- a/packages/business/src/get-ongoing-clinical-trials.ts
+++ b/packages/business/src/get-ongoing-clinical-trials.ts
@@ -1,8 +1,22 @@
-import { GetOnGoingClinicalTrials } from './domain'
+import {ClinicalTrial, GetOnGoingClinicalTrials, OnGoingFilter} from './domain'
 
-const getOnGoingClinicalTrials: GetOnGoingClinicalTrials = findClinicalTrials => filter => {
-  const now = new Date()
-  return findClinicalTrials({ ...filter, before: now, after: now, cancel: false })
+type Filter = OnGoingFilter & {
+  before: Date,
+  after: Date,
 }
+
+const getOnGoingClinicalTrials: GetOnGoingClinicalTrials = findClinicalTrials => async (filter) => {
+  const now = new Date()
+  const clinicalTrials = await findClinicalTrials()
+  return filter ? filterClinicalTrials(clinicalTrials, { ...filter, before: now, after: now }) : clinicalTrials
+}
+
+const filterClinicalTrials = (clinicalTrials: ClinicalTrial[], filter: Filter) =>
+  clinicalTrials.filter(trial => {
+    return (trial.endDate.getTime() > filter.after.getTime())
+      && (trial.startDate.getTime() < filter.before.getTime())
+      && (!filter.sponsorName || (trial.sponsor === filter.sponsorName))
+      && (!filter.countryCode || (trial.country.code === filter.countryCode))
+  })
 
 export { getOnGoingClinicalTrials }

--- a/packages/business/src/ports/repository.ts
+++ b/packages/business/src/ports/repository.ts
@@ -1,13 +1,5 @@
-import { ClinicalTrial, CountryCode } from '../domain'
+import { ClinicalTrial } from '../domain'
 
-type Filter = {
-  sponsorName?: string,
-  countryCode?: CountryCode,
-  before?: Date,
-  after?: Date,
-  cancel?: boolean,
-}
+type FindClinicalTrials = () => Promise<ClinicalTrial[]>
 
-type FindClinicalTrials = (filter?: Filter) => Promise<ClinicalTrial[]>
-
-export { Filter, FindClinicalTrials }
+export { FindClinicalTrials }

--- a/packages/business/test/adapters/static-file-repository.test.ts
+++ b/packages/business/test/adapters/static-file-repository.test.ts
@@ -4,37 +4,9 @@ import { describe, it } from 'node:test'
 import { findClinicalTrials } from '../../src/adapters'
 
 describe('Find clinical trials from static file', () => {
-  describe('without filter', () => {
-    it('should return all the clinical trials', async () => {
-      const clinicalTrials = await findClinicalTrials()
+  it('should return all the clinical trials', async () => {
+    const clinicalTrials = await findClinicalTrials()
 
-      assert.equal(clinicalTrials.length, 6)
-    })
-  })
-
-  describe('with the on going dates of 2018-06-10', () => {
-    it('should return 2 old clinical trials', async () => {
-      const now = new Date(2018, 5, 10)
-      const clinicalTrials = await findClinicalTrials({ before: now, after: now })
-
-      assert.equal(clinicalTrials.length, 2)
-      assert.deepEqual(clinicalTrials.map(trial => trial.name), [
-        'Topical Calcipotriene Treatment for Breast Cancer Immunoprevention',
-        'Neratinib +/- Fulvestrant in HER2+, ER+ Metastatic Breast Cancer',
-      ])
-    })
-  })
-
-  describe('with sponsor Sanofi and the on going dates in august 2023', () => {
-    it('should return the 2 Sanofi clinical trials', async () => {
-      const now = new Date(2023, 7, 10)
-      const clinicalTrials = await findClinicalTrials({ before: now, after: now, sponsorName: 'Sanofi' })
-
-      assert.equal(clinicalTrials.length, 2)
-      assert.deepEqual(clinicalTrials.map(trial => trial.name), [
-        'Olaparib + Sapacitabine in BRCA Mutant Breast Cancer',
-        'Topical Calcipotriene Treatment for Breast Cancer Immunoprevention',
-      ])
-    })
+    assert.equal(clinicalTrials.length, 6)
   })
 })

--- a/packages/business/test/adapters/static-file-repository.test.ts
+++ b/packages/business/test/adapters/static-file-repository.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
-import { findClinicalTrials } from '../../src/adapters/static-file-repository'
+import { findClinicalTrials } from '../../src/adapters'
 
 describe('Find clinical trials from static file', () => {
   describe('without filter', () => {

--- a/packages/business/test/factories/clinical-trials.ts
+++ b/packages/business/test/factories/clinical-trials.ts
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker'
 import * as Factory from 'factory.ts'
 
-import {COUNTRIES, ClinicalTrial, Country, CountryCode} from '../../src/domain'
+import { COUNTRIES, ClinicalTrial, Country, CountryCode } from '../../src/domain'
 
 const generateCountry = (): Country => {
   const countries = Object.entries(COUNTRIES)

--- a/packages/business/test/get-ongoing-clinical-trials.test.ts
+++ b/packages/business/test/get-ongoing-clinical-trials.test.ts
@@ -3,8 +3,8 @@ import { afterEach, beforeEach, describe, it } from 'node:test'
 import sinon from 'sinon'
 
 import { ClinicalTrial } from '../src/domain'
-import { Filter } from '../src/ports/repository'
-import { getOnGoingClinicalTrials } from '../src/get-ongoing-clinical-trials'
+import { Filter } from '../src/ports'
+import { getOnGoingClinicalTrials } from '../src'
 
 import { clinicalTrialsFactory } from './factories/clinical-trials'
 

--- a/packages/business/test/get-ongoing-clinical-trials.test.ts
+++ b/packages/business/test/get-ongoing-clinical-trials.test.ts
@@ -1,45 +1,20 @@
 import assert from 'node:assert/strict'
-import { afterEach, beforeEach, describe, it } from 'node:test'
+import { beforeEach, describe, it } from 'node:test'
+import { faker } from '@faker-js/faker'
 import sinon from 'sinon'
 
 import { ClinicalTrial } from '../src/domain'
-import { Filter } from '../src/ports'
 import { getOnGoingClinicalTrials } from '../src'
 
 import { clinicalTrialsFactory } from './factories/clinical-trials'
 
 describe('Get OnGoing clinical trials', () => {
-  const now = new Date()
-  let clock,
-    sandbox: sinon.SinonSandbox,
-    findClinicalTrials: sinon.SinonStub<sinon.SinonStubArgs<Filter>, Promise<ClinicalTrial[]>>
+  let sandbox: sinon.SinonSandbox,
+    findClinicalTrials: sinon.SinonStub<void, Promise<ClinicalTrial[]>>
 
   beforeEach(() => {
-    clock = sinon.useFakeTimers(now.getTime())
     sandbox = sinon.createSandbox()
     findClinicalTrials = sandbox.stub()
-  })
-
-  afterEach(() => clock.restore())
-
-  it('should call the repository with the right dates and cancel', async () => {
-    await getOnGoingClinicalTrials(findClinicalTrials)()
-
-    assert.ok(findClinicalTrials.withArgs({ cancel: false, before: now, after: now }).calledOnce)
-  })
-
-  describe('When a sponsor name and a country code are provided in the search filter', () => {
-    it('should call the repository with the right dates, cancel, sponsor name and country code', async () => {
-      await getOnGoingClinicalTrials(findClinicalTrials)({ sponsorName: 'Sanofi', countryCode: 'DE' })
-
-      assert.ok(findClinicalTrials.withArgs({
-        cancel: false,
-        before: now,
-        after: now,
-        sponsorName: 'Sanofi',
-        countryCode: 'DE',
-      }).calledOnce)
-    })
   })
 
   describe('When the repository does not return any result', () => {
@@ -54,13 +29,20 @@ describe('Get OnGoing clinical trials', () => {
   })
 
   describe('When the repository return some trials', () => {
-    it('should return the same trials', async () => {
-      const onGoingClinicalTrials = clinicalTrialsFactory.buildList(3)
+    it('should return the matching filtered trials', async () => {
+      const onGoingClinicalTrials = [
+        clinicalTrialsFactory.build({ sponsor: 'Sanofi', country: { code: 'FR' } }),
+        clinicalTrialsFactory.build({ sponsor: 'Sanofi', country: { code: 'FR' } }),
+        clinicalTrialsFactory.build({ sponsor: 'Glaxo', country: { code: 'FR' } }),
+        clinicalTrialsFactory.build({ sponsor: 'Sanofi', country: { code: 'FR' }, endDate: faker.date.past() }),
+        clinicalTrialsFactory.build({ sponsor: 'Sanofi', country: { code: 'DE' }  }),
+      ]
       findClinicalTrials.resolves(onGoingClinicalTrials)
 
-      const clinicalTrials = await getOnGoingClinicalTrials(findClinicalTrials)()
+      const clinicalTrials =
+        await getOnGoingClinicalTrials(findClinicalTrials)({ sponsorName: 'Sanofi', countryCode: 'FR' })
 
-      assert.deepEqual(clinicalTrials, onGoingClinicalTrials)
+      assert.deepEqual(clinicalTrials, onGoingClinicalTrials.slice(0, 2))
     })
   })
 })


### PR DESCRIPTION
To ensure data consistency and simplify the repository implementation, clinical trial filtering is done in the use case instead of the repository.
