### PR TITLE
✨ Implement a `cli`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,10 +3,16 @@
   "packageManager": "yarn@3.6.1",
   "scripts": {
     "compile": "tsc --noEmit",
-    "start": "ts-node src/index.ts"
+    "start": "ts-node src/index.ts",
+    "ts": "node --require esbuild-register",
+    "test": "yarn ts --test test/**/*.test.ts"
   },
   "devDependencies": {
     "@types/node": "^20.4.5",
+    "@types/sinon": "^10.0.16",
+    "esbuild": "^0.19.2",
+    "esbuild-register": "^3.4.2",
+    "sinon": "^15.2.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.6"
   },

--- a/packages/cli/src/call-clinical-trials.ts
+++ b/packages/cli/src/call-clinical-trials.ts
@@ -1,0 +1,24 @@
+type ClinicalTrialAPI = {
+  name: string
+  sponsor: string
+  country: { name: string }
+}
+
+type Fetch = (url: URL) => Promise<Response>
+
+type SearchFilter = { sponsor?: string, country?: string }
+type CallClinicalTrials = (path: string, searchFilter?: SearchFilter) => Promise<string>
+
+const URL_BASE = "http://localhost:8080"
+
+const callClinicalTrialsCommand = (fetch: Fetch): CallClinicalTrials => async (path, { sponsor, country} = {}) => {
+  const url = new URL(path, URL_BASE)
+  sponsor && url.searchParams.append('sponsor', sponsor)
+  country && url.searchParams.append('country', country)
+
+  const response: Response = await fetch(url)
+  const clinicalTrials: ClinicalTrialAPI[] = await response.json()
+  return clinicalTrials.map(trial => `${trial.name}, ${trial.country.name}`).join("\n")
+}
+
+export { CallClinicalTrials, ClinicalTrialAPI, Fetch, SearchFilter, callClinicalTrialsCommand }

--- a/packages/cli/src/call-clinical-trials.ts
+++ b/packages/cli/src/call-clinical-trials.ts
@@ -4,6 +4,19 @@ type ClinicalTrialAPI = {
   country: { name: string }
 }
 
+type BadRequestError = {
+  errors: [{
+    type: string
+    value: string
+    msg: string
+    path: string
+  }]
+}
+
+type UnknownError = {}
+
+type Body = ClinicalTrialAPI[] | BadRequestError | UnknownError
+
 type Fetch = (url: URL) => Promise<Response>
 
 type SearchFilter = { sponsor?: string, country?: string }
@@ -17,8 +30,30 @@ const callClinicalTrialsCommand = (fetch: Fetch): CallClinicalTrials => async (p
   country && url.searchParams.append('country', country)
 
   const response: Response = await fetch(url)
-  const clinicalTrials: ClinicalTrialAPI[] = await response.json()
-  return clinicalTrials.map(trial => `${trial.name}, ${trial.country.name}`).join("\n")
+  const body: Body = await response.json()
+
+  let result = unknownErrorMessage()
+  if (isOk(response)) {
+    result = clinicalTrialsMessage(body as ClinicalTrialAPI[])
+  }
+  else if (isBadRequest(response)) {
+    result = errorMessage(body as BadRequestError)
+  }
+
+  return result
 }
+
+const isOk = (response: Response): boolean => response.status < 400
+
+const isBadRequest = (response: Response): boolean => response.status === 400
+
+const clinicalTrialsMessage = (clinicalTrials: ClinicalTrialAPI[]): string =>
+  clinicalTrials.map(trial => `${trial.name}, ${trial.country.name}`).join("\n")
+
+const errorMessage = (error: BadRequestError): string =>
+  error.errors.map(error => `${error.msg} "${error.value}" for ${error.type} ${error.path}`).join("\n")
+
+const unknownErrorMessage = (): string =>
+  'An unknown error occurred. You can retry in a few moments and contact the development team if the problem persists.'
 
 export { CallClinicalTrials, ClinicalTrialAPI, Fetch, SearchFilter, callClinicalTrialsCommand }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,12 +1,15 @@
-import { program } from "commander";
+import { program } from "commander"
+import { callClinicalTrialsCommand } from "./call-clinical-trials"
 
 program
   .name("inato-cli")
   .command("trials")
-  .description("get the list of clinical trials")
-  .requiredOption("-p, --path <type>", "the api path to call")
-  .action(async function ({ path }) {
-    const response = await fetch(`http://localhost:8080/${path}`);
-    console.log(await response.text());
+  .description("get the list of ongoing clinical trials")
+  .option("-p, --path <type>", "the api path to call", "on-goings")
+  .option("-s, --sponsor <sponsor name>", "the sponsor name of the clinical trials")
+  .option("-c, --country <country code>", "the country code where the clinical trials are being conducted")
+  .action(async function ({ path, sponsor, country }) {
+    const clinicalTrials = await callClinicalTrialsCommand(fetch)(path, {sponsor, country})
+    console.log(clinicalTrials)
   })
-  .parseAsync(process.argv);
+  .parseAsync(process.argv)

--- a/packages/cli/test/call-clinical-trials.test.ts
+++ b/packages/cli/test/call-clinical-trials.test.ts
@@ -2,40 +2,20 @@ import assert from "node:assert/strict"
 import { beforeEach, describe, it } from "node:test"
 import sinon from "sinon"
 
-import {
-  CallClinicalTrials,
-  callClinicalTrialsCommand,
-} from "../src/call-clinical-trials"
+import { callClinicalTrialsCommand } from "../src/call-clinical-trials"
 
 describe('Call clinical trials', () => {
   let sandbox: sinon.SinonSandbox,
-    fetch: sinon.SinonStub<URL[], Promise<Response>>,
-    callClinicalTrials: CallClinicalTrials
+    fetch: sinon.SinonStub<URL[], Promise<Response>>
 
   beforeEach(() => {
     sandbox = sinon.createSandbox()
-    fetch = sandbox.stub().resolves({ json: sandbox.stub().resolves([
-      {
-        "country": { name: "France" },
-        "end_date": "2025-07-31",
-        "name": "Olaparib + Sapacitabine in BRCA Mutant Breast Cancer",
-        "sponsor": "Sanofi",
-        "start_date": "2018-12-31"
-      },
-      {
-        "country": { name: "France" },
-        "end_date": "2032-09-09",
-        "name": "Topical Calcipotriene Treatment for Breast Cancer Immunoprevention",
-        "sponsor": "Sanofi",
-        "start_date": "2018-03-19"
-      }
-    ])})
-    callClinicalTrials = callClinicalTrialsCommand(fetch)
+    fetch = sandbox.stub().resolves({ status: 200, json: sandbox.stub().resolves([]) })
   })
 
   describe('when is calling with a path only', () => {
     it('should fetch the service without query params', async () => {
-      await callClinicalTrials('ongoings')
+      await callClinicalTrialsCommand(fetch)('ongoings')
 
       assert.ok(fetch.withArgs(new URL("http://localhost:8080/ongoings")).calledOnce)
     })
@@ -43,7 +23,7 @@ describe('Call clinical trials', () => {
 
   describe('when is calling with a path and a sponsor name filter', () => {
     it('should fetch the service with sponsor as query param', async () => {
-      await callClinicalTrials('ongoings', { sponsor: "Sanofi" })
+      await callClinicalTrialsCommand(fetch)('ongoings', { sponsor: "Sanofi" })
 
       assert.ok(fetch.withArgs(new URL("http://localhost:8080/ongoings?sponsor=Sanofi")).calledOnce)
     })
@@ -51,7 +31,7 @@ describe('Call clinical trials', () => {
 
   describe('when is calling with a path and a country code filter', () => {
     it('should fetch the service with country as query param', async () => {
-      await callClinicalTrials('ongoings', { country: "FR" })
+      await callClinicalTrialsCommand(fetch)('ongoings', { country: "FR" })
 
       assert.ok(fetch.withArgs(new URL("http://localhost:8080/ongoings?country=FR")).calledOnce)
     })
@@ -59,18 +39,73 @@ describe('Call clinical trials', () => {
 
   describe('when is calling with a path, sponsor and a country code filter', () => {
     it('should fetch the service with sponsor and country as query params', async () => {
-      await callClinicalTrials('ongoings', { sponsor: "Glaxo Smith & Kline", country: "EN" })
+      await callClinicalTrialsCommand(fetch)('ongoings', { sponsor: "Glaxo Smith & Kline", country: "EN" })
 
       assert.ok(fetch.withArgs(new URL("http://localhost:8080/ongoings?sponsor=Glaxo+Smith+%26+Kline&country=EN")).calledOnce)
     })
   })
 
-  it('should return the clinical trials name with the country', async () => {
-    const clinicalTrials = await callClinicalTrials('ongoings', { sponsor: "Sanofi", country: "FR" })
+  describe('when is calling with a good filter values', () => {
+    beforeEach(() => {
+      fetch = sandbox.stub().resolves({
+        status: 200,
+        json: sandbox.stub().resolves([{
+          "country": { name: "France" },
+          "end_date": "2025-07-31",
+          "name": "Olaparib + Sapacitabine in BRCA Mutant Breast Cancer",
+          "sponsor": "Sanofi",
+          "start_date": "2018-12-31"
+        },
+          {
+            "country": { name: "France" },
+            "end_date": "2032-09-09",
+            "name": "Topical Calcipotriene Treatment for Breast Cancer Immunoprevention",
+            "sponsor": "Sanofi",
+            "start_date": "2018-03-19"
+          }
+        ])
+      })
+    })
 
-    assert.equal(clinicalTrials, `
+    it('should return the clinical trials name with the country', async () => {
+      const clinicalTrials = await callClinicalTrialsCommand(fetch)('ongoings', { sponsor: "Sanofi", country: "FR" })
+
+      assert.equal(clinicalTrials, `
 Olaparib + Sapacitabine in BRCA Mutant Breast Cancer, France
 Topical Calcipotriene Treatment for Breast Cancer Immunoprevention, France
 `.trim())
+    })
+  })
+
+  describe('when is calling with a bad filter value', () => {
+    it('should return an error message', async () => {
+      fetch = sandbox.stub().resolves({
+        status: 400,
+        json: sandbox.stub().resolves({
+          errors: [{
+            type: 'field',
+            value: 'FDD',
+            msg: 'Invalid value',
+            path: 'country',
+            location: 'query'
+          }]
+        })
+      })
+      const clinicalTrials = await callClinicalTrialsCommand(fetch)('ongoings', { country: "FFF" })
+
+      assert.equal(clinicalTrials, 'Invalid value "FDD" for field country')
+    })
+  })
+
+  describe('when the fetch is failing for unknown reason', () => {
+    it('should return an unknown error message', async () => {
+      fetch = sandbox.stub().resolves({
+        status: 500,
+        json: sandbox.stub().resolves({})
+      })
+      const clinicalTrials = await callClinicalTrialsCommand(fetch)('ongoings', { country: "FFF" })
+
+      assert.equal(clinicalTrials, 'An unknown error occurred. You can retry in a few moments and contact the development team if the problem persists.')
+    })
   })
 })

--- a/packages/cli/test/call-clinical-trials.test.ts
+++ b/packages/cli/test/call-clinical-trials.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict"
+import { beforeEach, describe, it } from "node:test"
+import sinon from "sinon"
+
+import {
+  CallClinicalTrials,
+  callClinicalTrialsCommand,
+} from "../src/call-clinical-trials"
+
+describe('Call clinical trials', () => {
+  let sandbox: sinon.SinonSandbox,
+    fetch: sinon.SinonStub<URL[], Promise<Response>>,
+    callClinicalTrials: CallClinicalTrials
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+    fetch = sandbox.stub().resolves({ json: sandbox.stub().resolves([
+      {
+        "country": { name: "France" },
+        "end_date": "2025-07-31",
+        "name": "Olaparib + Sapacitabine in BRCA Mutant Breast Cancer",
+        "sponsor": "Sanofi",
+        "start_date": "2018-12-31"
+      },
+      {
+        "country": { name: "France" },
+        "end_date": "2032-09-09",
+        "name": "Topical Calcipotriene Treatment for Breast Cancer Immunoprevention",
+        "sponsor": "Sanofi",
+        "start_date": "2018-03-19"
+      }
+    ])})
+    callClinicalTrials = callClinicalTrialsCommand(fetch)
+  })
+
+  describe('when is calling with a path only', () => {
+    it('should fetch the service without query params', async () => {
+      await callClinicalTrials('ongoings')
+
+      assert.ok(fetch.withArgs(new URL("http://localhost:8080/ongoings")).calledOnce)
+    })
+  })
+
+  describe('when is calling with a path and a sponsor name filter', () => {
+    it('should fetch the service with sponsor as query param', async () => {
+      await callClinicalTrials('ongoings', { sponsor: "Sanofi" })
+
+      assert.ok(fetch.withArgs(new URL("http://localhost:8080/ongoings?sponsor=Sanofi")).calledOnce)
+    })
+  })
+
+  describe('when is calling with a path and a country code filter', () => {
+    it('should fetch the service with country as query param', async () => {
+      await callClinicalTrials('ongoings', { country: "FR" })
+
+      assert.ok(fetch.withArgs(new URL("http://localhost:8080/ongoings?country=FR")).calledOnce)
+    })
+  })
+
+  describe('when is calling with a path, sponsor and a country code filter', () => {
+    it('should fetch the service with sponsor and country as query params', async () => {
+      await callClinicalTrials('ongoings', { sponsor: "Glaxo Smith & Kline", country: "EN" })
+
+      assert.ok(fetch.withArgs(new URL("http://localhost:8080/ongoings?sponsor=Glaxo+Smith+%26+Kline&country=EN")).calledOnce)
+    })
+  })
+
+  it('should return the clinical trials name with the country', async () => {
+    const clinicalTrials = await callClinicalTrials('ongoings', { sponsor: "Sanofi", country: "FR" })
+
+    assert.equal(clinicalTrials, `
+Olaparib + Sapacitabine in BRCA Mutant Breast Cancer, France
+Topical Calcipotriene Treatment for Breast Cancer Immunoprevention, France
+`.trim())
+  })
+})


### PR DESCRIPTION
This is the `inato-cli` command-line interface that displays the list of ongoing clinical trials for a given country code.
It calls the web server API that is running locally on the user's computer.
Here is the `inato-cli` cli description
```
Usage: inato-cli trials [options]

get the list of ongoing clinical trials

Options:
  -p, --path <type>             the api path to call (default: "on-goings")
  -s, --sponsor <sponsor name>  the sponsor name of the clinical trials
  -c, --country <country code>  the country code where the clinical trials are being conducted
  -h, --help                    display help for command
```