### PR TITLE
🐛  `GetOnGoingClinical` trials does not work

### DIFF
--- a/packages/business/src/adapters/static-file-repository.ts
+++ b/packages/business/src/adapters/static-file-repository.ts
@@ -10,6 +10,7 @@ type ApiClinicalTrial = {
   sponsor: string
   end_date: string
   start_date: string
+  canceled: boolean
 }
 
 const TRIALS_FILE_PATH_FROM_HERE = '/../../../../trials.json'
@@ -45,6 +46,7 @@ const toClinicalTrial = (apiClinicalTrial: ApiClinicalTrial): ClinicalTrial => {
     startDate,
     endDate,
     sponsor: apiClinicalTrial.sponsor,
+    canceled: apiClinicalTrial.canceled,
   }
 }
 

--- a/packages/business/src/domain/entities.ts
+++ b/packages/business/src/domain/entities.ts
@@ -20,6 +20,7 @@ type ClinicalTrial = {
   sponsor: string
   startDate: Date
   endDate: Date
+  canceled: boolean
 }
 
 export { COUNTRIES, Country, CountryCode, CountryName, ClinicalTrial }

--- a/packages/business/src/get-ongoing-clinical-trials.ts
+++ b/packages/business/src/get-ongoing-clinical-trials.ts
@@ -1,22 +1,21 @@
 import {ClinicalTrial, GetOnGoingClinicalTrials, OnGoingFilter} from './domain'
 
-type Filter = OnGoingFilter & {
-  before: Date,
-  after: Date,
-}
-
-const getOnGoingClinicalTrials: GetOnGoingClinicalTrials = findClinicalTrials => async (filter) => {
-  const now = new Date()
+const getOnGoingClinicalTrials: GetOnGoingClinicalTrials = findClinicalTrials => async (filter= {}) => {
   const clinicalTrials = await findClinicalTrials()
-  return filter ? filterClinicalTrials(clinicalTrials, { ...filter, before: now, after: now }) : clinicalTrials
+  return filterClinicalTrials(clinicalTrials, filter)
 }
 
-const filterClinicalTrials = (clinicalTrials: ClinicalTrial[], filter: Filter) =>
-  clinicalTrials.filter(trial => {
-    return (trial.endDate.getTime() > filter.after.getTime())
-      && (trial.startDate.getTime() < filter.before.getTime())
+const filterClinicalTrials = (clinicalTrials: ClinicalTrial[], filter: OnGoingFilter) =>
+  clinicalTrials.filter(trial =>
+    isOnGoingClinicalTrial(trial)
       && (!filter.sponsorName || (trial.sponsor === filter.sponsorName))
-      && (!filter.countryCode || (trial.country.code === filter.countryCode))
-  })
+      && (!filter.countryCode || (trial.country.code === filter.countryCode)))
+
+const isOnGoingClinicalTrial = (clinicalTrial: ClinicalTrial): boolean => {
+  const now = new Date()
+  return (clinicalTrial.endDate.getTime() > now.getTime())
+    && (clinicalTrial.startDate.getTime() < now.getTime())
+    && (!clinicalTrial.canceled)
+}
 
 export { getOnGoingClinicalTrials }

--- a/packages/business/test/factories/clinical-trials.ts
+++ b/packages/business/test/factories/clinical-trials.ts
@@ -19,6 +19,7 @@ const clinicalTrialsFactory = Factory.Sync.makeFactory<ClinicalTrial>({
   sponsor: Factory.each(() => faker.company.name()),
   startDate: Factory.each(() => faker.date.past()),
   endDate: Factory.each(() => faker.date.future()),
+  canceled: Factory.each(() => false),
 })
 
 export { clinicalTrialsFactory }

--- a/packages/business/test/get-ongoing-clinical-trials.test.ts
+++ b/packages/business/test/get-ongoing-clinical-trials.test.ts
@@ -29,6 +29,31 @@ describe('Get OnGoing clinical trials', () => {
   })
 
   describe('When the repository return some trials', () => {
+    it('should return only not canceled clinical trial', async () => {
+      const onGoingClinicalTrials = [
+        clinicalTrialsFactory.build({ canceled: false }),
+        clinicalTrialsFactory.build({ canceled: true }),
+      ]
+      findClinicalTrials.resolves(onGoingClinicalTrials)
+
+      const clinicalTrials = await getOnGoingClinicalTrials(findClinicalTrials)()
+
+      assert.deepEqual(clinicalTrials, onGoingClinicalTrials.slice(0, 1))
+    })
+
+    it('should return trials with start date in the past and end date in the future ', async () => {
+      const onGoingClinicalTrials = [
+        clinicalTrialsFactory.build({ startDate: faker.date.past(), endDate: faker.date.future() }),
+        clinicalTrialsFactory.build({ startDate: faker.date.future() }),
+        clinicalTrialsFactory.build({ endDate: faker.date.past() }),
+      ]
+      findClinicalTrials.resolves(onGoingClinicalTrials)
+
+      const clinicalTrials = await getOnGoingClinicalTrials(findClinicalTrials)()
+
+      assert.deepEqual(clinicalTrials, onGoingClinicalTrials.slice(0, 1))
+    })
+
     it('should return the matching filtered trials', async () => {
       const onGoingClinicalTrials = [
         clinicalTrialsFactory.build({ sponsor: 'Sanofi', country: { code: 'FR' } }),


### PR DESCRIPTION
The notion of `canceled` clinical trial related to the OnGoing concept has not been implemented.
