### PR TITLE
🐛 Server fails when error occurs

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -2,11 +2,13 @@ import express, { Response } from 'express'
 
 import { Adapters } from './types'
 import { checkValidity, getOngoingClinicalTrialsHandler } from './handlers/get-ongoing-clinical-trials-handler'
+import { errorMiddleware } from './middlewares/error-handler'
 
 const createApp = (adapters: Adapters) =>
   express()
-  .get('/ping', (_req, res: Response) =>  res.send('pong'))
-  .get('/on-goings', checkValidity, getOngoingClinicalTrialsHandler(adapters))
+    .get('/ping', (_req, res: Response) =>  res.send('pong'))
+    .get('/on-goings', checkValidity, getOngoingClinicalTrialsHandler(adapters))
+    .use(errorMiddleware)
 
 const startApp = (adapters: Adapters, port = 8080) =>
   createApp(adapters).listen(port, () => console.log(`Server running on port ${port} 🍺`))

--- a/packages/api/src/handlers/get-ongoing-clinical-trials-handler.ts
+++ b/packages/api/src/handlers/get-ongoing-clinical-trials-handler.ts
@@ -38,7 +38,9 @@ const getOngoingClinicalTrialsHandler = ({ findClinicalTrials }: Adapters) => {
   return async (req: Request, res: express.Response) => {
     const result = validationResult(req)
     if (!result.isEmpty()) {
-      return res.status(400).json({ errors: result.array() })
+      return res.status(400).json({
+        error: result.array().map((error: FieldValidationError) => `${error.msg} "${error.value}" for ${error.type} ${error.path}`).join("\n")
+      })
     }
 
     const { sponsor, country } = req.query

--- a/packages/api/src/handlers/get-ongoing-clinical-trials-handler.ts
+++ b/packages/api/src/handlers/get-ongoing-clinical-trials-handler.ts
@@ -1,5 +1,5 @@
 import express from 'express'
-import { checkSchema, validationResult } from 'express-validator'
+import { checkSchema, FieldValidationError, validationResult } from 'express-validator'
 
 import { domain, getOnGoingClinicalTrials } from 'business'
 
@@ -35,7 +35,7 @@ const checkValidity = checkSchema({
 
 const getOngoingClinicalTrialsHandler = ({ findClinicalTrials }: Adapters) => {
   const findOnGoingClinicalTrials = getOnGoingClinicalTrials(findClinicalTrials)
-  return async (req: Request, res: express.Response) => {
+  return async (req: Request, res: express.Response, next: express.NextFunction) => {
     const result = validationResult(req)
     if (!result.isEmpty()) {
       return res.status(400).json({
@@ -43,9 +43,13 @@ const getOngoingClinicalTrialsHandler = ({ findClinicalTrials }: Adapters) => {
       })
     }
 
-    const { sponsor, country } = req.query
-    const onGoingClinicalTrials = await findOnGoingClinicalTrials({ sponsorName: sponsor, countryCode: country })
-    res.status(200).json(onGoingClinicalTrials.map(toOngoingClinicalTrial))
+    try {
+      const {sponsor, country} = req.query
+      const onGoingClinicalTrials = await findOnGoingClinicalTrials({sponsorName: sponsor, countryCode: country})
+      res.status(200).json(onGoingClinicalTrials.map(toOngoingClinicalTrial))
+    } catch (e) {
+      next(e)
+    }
   }
 }
 

--- a/packages/api/src/middlewares/error-handler.ts
+++ b/packages/api/src/middlewares/error-handler.ts
@@ -1,0 +1,15 @@
+import {ErrorRequestHandler} from "express"
+import {errors} from 'business'
+
+const errorMiddleware: ErrorRequestHandler = (err, req, res, next) => {
+  if (res.headersSent) {
+    return next(err)
+  }
+  if (err instanceof errors.BusinessError) {
+    res.status(400).json({ error: err.message })
+  } else {
+    res.status(500).json({ error: `An error occurred: ${err.message || "unknown error"}` })
+  }
+}
+
+export { errorMiddleware }

--- a/packages/api/test/handlers/get-ongoing-clinical-trials-handler.test.ts
+++ b/packages/api/test/handlers/get-ongoing-clinical-trials-handler.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { beforeEach, describe, it } from 'node:test'
+import { afterEach, beforeEach, describe, it } from 'node:test'
 import { Express } from 'express'
 import { faker } from '@faker-js/faker'
 import sinon from 'sinon'
@@ -21,41 +21,11 @@ describe('GetOngoingClinicalTrialsHandler', () => {
     sandbox = sinon.createSandbox()
     findClinicalTrials = sandbox.stub()
 
-    onGoingClinicalTrials = [
-      clinicalTrialsFactory.build({ sponsor: 'Sanofi', country: { code: 'FR' } }),
-      clinicalTrialsFactory.build({ sponsor: 'Sanofi', country: { code: 'FR' } }),
-      clinicalTrialsFactory.build({ sponsor: 'Sanofi', country: { code: 'DE' } }),
-      clinicalTrialsFactory.build({ sponsor: 'AstraZeneca', country: { code: 'FR' } }),
-      clinicalTrialsFactory.build({ sponsor: 'Sanofi', endDate: faker.date.past() }),
-    ]
-    findClinicalTrials.resolves(onGoingClinicalTrials)
-
-    app = createApp({ findClinicalTrials })
+    app = createApp({findClinicalTrials})
   })
 
-  it('should return the valid trials returned by findClinicalTrials', async () => {
-    const response = await request(app).get('/on-goings')
-
-    assert.equal(response.statusCode, 200)
-    assert.deepEqual(response.body, onGoingClinicalTrials.slice(0, 4).map(toOngoingClinicalTrial))
-  })
-
-  describe('when a sponsor name is provided as query params', () => {
-    it('should return the trials filtered by the sponsor', async () => {
-      const response = await request(app).get('/on-goings?sponsor=Sanofi')
-
-      assert.equal(response.statusCode, 200)
-      assert.deepEqual(response.body, onGoingClinicalTrials.slice(0, 3).map(toOngoingClinicalTrial))
-    })
-  })
-
-  describe('when a sponsor name and a country code are provided as query params', () => {
-    it('should return the trials filtered by the sponsor', async () => {
-      const response = await request(app).get('/on-goings?sponsor=Sanofi&country=FR')
-
-      assert.equal(response.statusCode, 200)
-      assert.deepEqual(response.body, onGoingClinicalTrials.slice(0, 2).map(toOngoingClinicalTrial))
-    })
+  afterEach(() => {
+    sandbox.reset()
   })
 
   describe('when the code country does not match an actual code', () => {
@@ -63,6 +33,44 @@ describe('GetOngoingClinicalTrialsHandler', () => {
       const response = await request(app).get('/on-goings?country=BAD')
 
       assert.equal(response.statusCode, 400)
+    })
+  })
+
+  describe('With succeed findClinicalTrials', () => {
+    beforeEach(() => {
+      onGoingClinicalTrials = [
+        clinicalTrialsFactory.build({sponsor: 'Sanofi', country: {code: 'FR'}}),
+        clinicalTrialsFactory.build({sponsor: 'Sanofi', country: {code: 'FR'}}),
+        clinicalTrialsFactory.build({sponsor: 'Sanofi', country: {code: 'DE'}}),
+        clinicalTrialsFactory.build({sponsor: 'AstraZeneca', country: {code: 'FR'}}),
+        clinicalTrialsFactory.build({sponsor: 'Sanofi', endDate: faker.date.past()}),
+      ]
+      findClinicalTrials.resolves(onGoingClinicalTrials)
+    })
+
+    it('should return the valid trials returned by findClinicalTrials', async () => {
+      const response = await request(app).get('/on-goings')
+
+      assert.equal(response.statusCode, 200)
+      assert.deepEqual(response.body, onGoingClinicalTrials.slice(0, 4).map(toOngoingClinicalTrial))
+    })
+
+    describe('when a sponsor name is provided as query params', () => {
+      it('should return the trials filtered by the sponsor', async () => {
+        const response = await request(app).get('/on-goings?sponsor=Sanofi')
+
+        assert.equal(response.statusCode, 200)
+        assert.deepEqual(response.body, onGoingClinicalTrials.slice(0, 3).map(toOngoingClinicalTrial))
+      })
+    })
+
+    describe('when a sponsor name and a country code are provided as query params', () => {
+      it('should return the trials filtered by the sponsor', async () => {
+        const response = await request(app).get('/on-goings?sponsor=Sanofi&country=FR')
+
+        assert.equal(response.statusCode, 200)
+        assert.deepEqual(response.body, onGoingClinicalTrials.slice(0, 2).map(toOngoingClinicalTrial))
+      })
     })
   })
 })

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,9 +1,8 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "composite": true,
-    "esModuleInterop": true,
     "outDir": "dist"
   },
-  "extends": "../../tsconfig.json",
   "include": ["src"]
 }

--- a/packages/business/src/adapters/static-file-repository.ts
+++ b/packages/business/src/adapters/static-file-repository.ts
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises'
 
 import { COUNTRIES, ClinicalTrial, Country, guards } from '../domain'
 import { FindClinicalTrials } from '../ports'
+import { ValidationError } from '../errors'
 
 type ApiClinicalTrial = {
   name: string
@@ -27,10 +28,10 @@ const loadJson = async <T = unknown>(filePath: string): Promise<T> => {
 
 const toClinicalTrial = (apiClinicalTrial: ApiClinicalTrial): ClinicalTrial => {
   const startDate = parseDate(apiClinicalTrial.start_date)
-  if (!startDate) throw new Error(`Bad start date ${apiClinicalTrial.start_date}`)
+  if (!startDate) throw new ValidationError(`Bad start date ${apiClinicalTrial.start_date}`)
 
   const endDate = parseDate(apiClinicalTrial.end_date)
-  if (!endDate) throw new Error(`Bad end date ${apiClinicalTrial.end_date}`)
+  if (!endDate) throw new ValidationError(`Bad end date ${apiClinicalTrial.end_date}`)
 
   const apiCountry = apiClinicalTrial.country.toUpperCase()
   const countryCode = guards.isCountryCode(apiCountry) ? apiCountry : null
@@ -38,7 +39,7 @@ const toClinicalTrial = (apiClinicalTrial: ApiClinicalTrial): ClinicalTrial => {
     code: countryCode,
     name: COUNTRIES[countryCode.toUpperCase()],
   }
-  if (!country) throw new Error(`Bad country ${apiClinicalTrial.country}`)
+  if (!country) throw new ValidationError(`Bad country ${apiClinicalTrial.country}`)
 
   return {
     name: apiClinicalTrial.name,

--- a/packages/business/src/errors.ts
+++ b/packages/business/src/errors.ts
@@ -1,0 +1,9 @@
+class BusinessError extends Error {}
+
+class ValidationError extends BusinessError {
+  constructor(cause: string) {
+    super(`A validation error has occurred: ${cause}`);
+  }
+}
+
+export { BusinessError, ValidationError }

--- a/packages/business/src/index.ts
+++ b/packages/business/src/index.ts
@@ -1,4 +1,5 @@
-export * from './get-ongoing-clinical-trials'
-export * as domain from './domain'
-export * as ports from './ports'
 export * as adapters from './adapters'
+export * as domain from './domain'
+export * as errors from './errors'
+export * as ports from './ports'
+export * from './get-ongoing-clinical-trials'

--- a/packages/cli/src/call-clinical-trials.ts
+++ b/packages/cli/src/call-clinical-trials.ts
@@ -5,12 +5,7 @@ type ClinicalTrialAPI = {
 }
 
 type BadRequestError = {
-  errors: [{
-    type: string
-    value: string
-    msg: string
-    path: string
-  }]
+  error: string
 }
 
 type UnknownError = {}
@@ -50,8 +45,7 @@ const isBadRequest = (response: Response): boolean => response.status === 400
 const clinicalTrialsMessage = (clinicalTrials: ClinicalTrialAPI[]): string =>
   clinicalTrials.map(trial => `${trial.name}, ${trial.country.name}`).join("\n")
 
-const errorMessage = (error: BadRequestError): string =>
-  error.errors.map(error => `${error.msg} "${error.value}" for ${error.type} ${error.path}`).join("\n")
+const errorMessage = (badRequestError: BadRequestError): string => badRequestError.error
 
 const unknownErrorMessage = (): string =>
   'An unknown error occurred. You can retry in a few moments and contact the development team if the problem persists.'

--- a/packages/cli/test/call-clinical-trials.test.ts
+++ b/packages/cli/test/call-clinical-trials.test.ts
@@ -81,15 +81,7 @@ Topical Calcipotriene Treatment for Breast Cancer Immunoprevention, France
     it('should return an error message', async () => {
       fetch = sandbox.stub().resolves({
         status: 400,
-        json: sandbox.stub().resolves({
-          errors: [{
-            type: 'field',
-            value: 'FDD',
-            msg: 'Invalid value',
-            path: 'country',
-            location: 'query'
-          }]
-        })
+        json: sandbox.stub().resolves({ error: 'Invalid value "FDD" for field country' })
       })
       const clinicalTrials = await callClinicalTrialsCommand(fetch)('ongoings', { country: "FFF" })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,8 @@
   ],
   "compilerOptions": {
     "resolveJsonModule": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "target": "ES2015"
   }
 }


### PR DESCRIPTION
In some cases, the business `GetOnGoingClinicalTrials` could throw an error.
It's not really that serious because `express` provides a default error handler.
The problem is because we use `express` in version 4, `Promise` implementation of middleware is not well supported and the `next` function with the error is not called automatically.
In this case, no middleware sends a response to the client.
